### PR TITLE
Set not supported metrics to null

### DIFF
--- a/lib/check/controller.py
+++ b/lib/check/controller.py
@@ -19,9 +19,9 @@ async def check_controller(
 
     for item in state.get('cpqDaCntlrEntry', []):
         if item.get('cpqDaCntlrBlinkTime') == MAX_INT:
-            item['cpqDaCntlrBlinkTime'] = None
+            item.pop('cpqDaCntlrBlinkTime')
         if item.get('cpqDaCntlrPartnerSlot') == -1:
-            item['cpqDaCntlrPartnerSlot'] = None
+            item.pop('cpqDaCntlrPartnerSlot')
         if item.get('cpqDaCntlrCurrentTemp') == -1:
-            item['cpqDaCntlrCurrentTemp'] = None
+            item.pop('cpqDaCntlrCurrentTemp')
     return state

--- a/lib/check/controller.py
+++ b/lib/check/controller.py
@@ -3,6 +3,7 @@ from libprobe.asset import Asset
 from ..snmpclient import get_snmp_client
 from ..snmpquery import snmpquery
 
+MAX_INT = 2 ** 32 - 1
 QUERIES = (
     (MIB_INDEX['CPQIDA-MIB']['cpqDaCntlrEntry'], True),
 )
@@ -15,4 +16,8 @@ async def check_controller(
 
     snmp = get_snmp_client(asset, asset_config, check_config)
     state = await snmpquery(snmp, QUERIES)
+
+    for item in state.get('cpqDaCntlrEntry', []):
+        if item.get('cpqDaCntlrBlinkTime') == MAX_INT:
+            item['cpqDaCntlrBlinkTime'] = None
     return state

--- a/lib/check/controller.py
+++ b/lib/check/controller.py
@@ -20,4 +20,8 @@ async def check_controller(
     for item in state.get('cpqDaCntlrEntry', []):
         if item.get('cpqDaCntlrBlinkTime') == MAX_INT:
             item['cpqDaCntlrBlinkTime'] = None
+        if item.get('cpqDaCntlrPartnerSlot') == -1:
+            item['cpqDaCntlrPartnerSlot'] = None
+        if item.get('cpqDaCntlrCurrentTemp') == -1:
+            item['cpqDaCntlrCurrentTemp'] = None
     return state

--- a/lib/check/eventlog.py
+++ b/lib/check/eventlog.py
@@ -18,8 +18,8 @@ async def check_eventlog(
     for item in state.get('cpqHeEventLogEntry', []):
         item.pop('cpqHeEventLogFreeFormData', None)
         if item.get('cpqDaLogDrvRebuildingPhyDrv') == -1:
-            item['cpqDaLogDrvRebuildingPhyDrv'] = None
+            item.pop('cpqDaLogDrvRebuildingPhyDrv')
         if item.get('cpqDaLogDrvCacheVolIndex') == -1:
-            item['cpqDaLogDrvCacheVolIndex'] = None
+            item.pop('cpqDaLogDrvCacheVolIndex')
 
     return state

--- a/lib/check/eventlog.py
+++ b/lib/check/eventlog.py
@@ -17,4 +17,9 @@ async def check_eventlog(
     state = await snmpquery(snmp, QUERIES)
     for item in state.get('cpqHeEventLogEntry', []):
         item.pop('cpqHeEventLogFreeFormData', None)
+        if item.get('cpqDaLogDrvRebuildingPhyDrv') == -1:
+            item['cpqDaLogDrvRebuildingPhyDrv'] = None
+        if item.get('cpqDaLogDrvCacheVolIndex') == -1:
+            item['cpqDaLogDrvCacheVolIndex'] = None
+
     return state

--- a/lib/check/storage.py
+++ b/lib/check/storage.py
@@ -14,6 +14,12 @@ async def check_storage(
         asset: Asset,
         asset_config: dict,
         check_config: dict):
+    # cpqDaPhyDrvSSDEstTimeRemainingHours might be -1 in some cases, this value
+    #   is provided as seconds on some devices, and minutes on other.
+    #   Be careful with using this metric as the unit is not honored by many
+    #   devices.
+    # cpqDaPhyDrvPowerOnHours might be represented in minutes on some hardware
+    #   while others return the value in hours.
 
     snmp = get_snmp_client(asset, asset_config, check_config)
     state = await snmpquery(snmp, QUERIES)

--- a/lib/check/storage.py
+++ b/lib/check/storage.py
@@ -45,4 +45,16 @@ async def check_storage(
             item['cpqDaPhyDrvSSDPercntEndrnceUsed'] = None
         if item.get('cpqDaPhyDrvSSDEstTimeRemainingHours') == MAX_INT:
             item['cpqDaPhyDrvSSDEstTimeRemainingHours'] = None
+        if item.get('cpqDaPhyDrvBusNumber') == -1:
+            item['cpqDaPhyDrvBusNumber'] = None
+        if item.get('cpqDaPhyDrvBoxOnConnector') == -1:
+            item['cpqDaPhyDrvBoxOnConnector'] = None
+        if item.get('cpqDaPhyDrvPhyCount') == -1:
+            item['cpqDaPhyDrvPhyCount'] = None
+        if item.get('cpqDaPhyDrvCurrentTemperature') == -1:
+            item['cpqDaPhyDrvCurrentTemperature'] = None
+        if item.get('cpqDaPhyDrvTemperatureThreshold') == -1:
+            item['cpqDaPhyDrvTemperatureThreshold'] = None
+        if item.get('cpqDaPhyDrvMaximumTemperature') == -1:
+            item['cpqDaPhyDrvMaximumTemperature'] = None
     return state

--- a/lib/check/storage.py
+++ b/lib/check/storage.py
@@ -20,41 +20,41 @@ async def check_storage(
 
     for item in state.get('cpqDaPhyDrvEntry', []):
         if item.get('cpqDaLogDrvPercentRebuild') == MAX_INT:
-            item['cpqDaLogDrvPercentRebuild'] = None
+            item.pop('cpqDaLogDrvPercentRebuild')
         if item.get('cpqDaLogDrvBlinkTime') == MAX_INT:
-            item['cpqDaLogDrvBlinkTime'] = None
+            item.pop('cpqDaLogDrvBlinkTime')
         if item.get('cpqDaLogDrvRPIPercentComplete') == MAX_INT:
-            item['cpqDaLogDrvRPIPercentComplete'] = None
+            item.pop('cpqDaLogDrvRPIPercentComplete')
 
     for item in state.get('cpqDaPhyDrvEntry', []):
         if item.get('cpqDaPhyDrvFunctTest1') == MAX_INT:
-            item['cpqDaPhyDrvFunctTest1'] = None
+            item.pop('cpqDaPhyDrvFunctTest1')
         if item.get('cpqDaPhyDrvFunctTest2') == MAX_INT:
-            item['cpqDaPhyDrvFunctTest2'] = None
+            item.pop('cpqDaPhyDrvFunctTest2')
         if item.get('cpqDaPhyDrvFunctTest3') == MAX_INT:
-            item['cpqDaPhyDrvFunctTest3'] = None
+            item.pop('cpqDaPhyDrvFunctTest3')
         if item.get('cpqDaPhyDrvDrqTimeouts') == MAX_INT:
-            item['cpqDaPhyDrvDrqTimeouts'] = None
+            item.pop('cpqDaPhyDrvDrqTimeouts')
         if item.get('cpqDaPhyDrvPostErrs') == MAX_INT:
-            item['cpqDaPhyDrvPostErrs'] = None
+            item.pop('cpqDaPhyDrvPostErrs')
         if item.get('cpqDaPhyDrvBlinkTime') == MAX_INT:
-            item['cpqDaPhyDrvBlinkTime'] = None
+            item.pop('cpqDaPhyDrvBlinkTime')
         if item.get('cpqDaPhyDrvPowerOnHours') == MAX_INT:
-            item['cpqDaPhyDrvPowerOnHours'] = None
+            item.pop('cpqDaPhyDrvPowerOnHours')
         if item.get('cpqDaPhyDrvSSDPercntEndrnceUsed') == MAX_INT:
-            item['cpqDaPhyDrvSSDPercntEndrnceUsed'] = None
+            item.pop('cpqDaPhyDrvSSDPercntEndrnceUsed')
         if item.get('cpqDaPhyDrvSSDEstTimeRemainingHours') == MAX_INT:
-            item['cpqDaPhyDrvSSDEstTimeRemainingHours'] = None
+            item.pop('cpqDaPhyDrvSSDEstTimeRemainingHours')
         if item.get('cpqDaPhyDrvBusNumber') == -1:
-            item['cpqDaPhyDrvBusNumber'] = None
+            item.pop('cpqDaPhyDrvBusNumber')
         if item.get('cpqDaPhyDrvBoxOnConnector') == -1:
-            item['cpqDaPhyDrvBoxOnConnector'] = None
+            item.pop('cpqDaPhyDrvBoxOnConnector')
         if item.get('cpqDaPhyDrvPhyCount') == -1:
-            item['cpqDaPhyDrvPhyCount'] = None
+            item.pop('cpqDaPhyDrvPhyCount')
         if item.get('cpqDaPhyDrvCurrentTemperature') == -1:
-            item['cpqDaPhyDrvCurrentTemperature'] = None
+            item.pop('cpqDaPhyDrvCurrentTemperature')
         if item.get('cpqDaPhyDrvTemperatureThreshold') == -1:
-            item['cpqDaPhyDrvTemperatureThreshold'] = None
+            item.pop('cpqDaPhyDrvTemperatureThreshold')
         if item.get('cpqDaPhyDrvMaximumTemperature') == -1:
-            item['cpqDaPhyDrvMaximumTemperature'] = None
+            item.pop('cpqDaPhyDrvMaximumTemperature')
     return state

--- a/lib/check/storage.py
+++ b/lib/check/storage.py
@@ -3,6 +3,7 @@ from libprobe.asset import Asset
 from ..snmpclient import get_snmp_client
 from ..snmpquery import snmpquery
 
+MAX_INT = 2 ** 32 - 1
 QUERIES = (
     (MIB_INDEX['CPQIDA-MIB']['cpqDaLogDrvEntry'], True),
     (MIB_INDEX['CPQIDA-MIB']['cpqDaPhyDrvEntry'], True),
@@ -16,4 +17,32 @@ async def check_storage(
 
     snmp = get_snmp_client(asset, asset_config, check_config)
     state = await snmpquery(snmp, QUERIES)
+
+    for item in state.get('cpqDaPhyDrvEntry', []):
+        if item.get('cpqDaLogDrvPercentRebuild') == MAX_INT:
+            item['cpqDaLogDrvPercentRebuild'] = None
+        if item.get('cpqDaLogDrvBlinkTime') == MAX_INT:
+            item['cpqDaLogDrvBlinkTime'] = None
+        if item.get('cpqDaLogDrvRPIPercentComplete') == MAX_INT:
+            item['cpqDaLogDrvRPIPercentComplete'] = None
+
+    for item in state.get('cpqDaPhyDrvEntry', []):
+        if item.get('cpqDaPhyDrvFunctTest1') == MAX_INT:
+            item['cpqDaPhyDrvFunctTest1'] = None
+        if item.get('cpqDaPhyDrvFunctTest2') == MAX_INT:
+            item['cpqDaPhyDrvFunctTest2'] = None
+        if item.get('cpqDaPhyDrvFunctTest3') == MAX_INT:
+            item['cpqDaPhyDrvFunctTest3'] = None
+        if item.get('cpqDaPhyDrvDrqTimeouts') == MAX_INT:
+            item['cpqDaPhyDrvDrqTimeouts'] = None
+        if item.get('cpqDaPhyDrvPostErrs') == MAX_INT:
+            item['cpqDaPhyDrvPostErrs'] = None
+        if item.get('cpqDaPhyDrvBlinkTime') == MAX_INT:
+            item['cpqDaPhyDrvBlinkTime'] = None
+        if item.get('cpqDaPhyDrvPowerOnHours') == MAX_INT:
+            item['cpqDaPhyDrvPowerOnHours'] = None
+        if item.get('cpqDaPhyDrvSSDPercntEndrnceUsed') == MAX_INT:
+            item['cpqDaPhyDrvSSDPercntEndrnceUsed'] = None
+        if item.get('cpqDaPhyDrvSSDEstTimeRemainingHours') == MAX_INT:
+            item['cpqDaPhyDrvSSDEstTimeRemainingHours'] = None
     return state

--- a/lib/check/system.py
+++ b/lib/check/system.py
@@ -38,6 +38,12 @@ def on_hofilesysentry(item: dict):
     percentused = item.pop('cpqHoFileSysPercentSpaceUsed', -1)
     if percentused >= 0:
         item['cpqHoFileSysPercentSpaceUsed'] = percentused
+    allocunitstotal = item.pop('cpqHoFileSysAllocUnitsTotal', -1)
+    if allocunitstotal >= 0:
+        item['cpqHoFileSysAllocUnitsTotal'] = allocunitstotal
+    allocunitsused = item.pop('cpqHoFileSysAllocUnitsUsed', -1)
+    if allocunitsused >= 0:
+        item['cpqHoFileSysAllocUnitsUsed'] = allocunitsused
     return item
 
 
@@ -64,4 +70,10 @@ async def check_system(
         item.pop('cpqSeCPUSerialNumberMfgr', None)
         item.pop('cpqSeCpuArchitectureRevision', None)
         item.pop('cpqSeCpuHwLocation', None)
+        if item.get('cpqSeCpuCurrentPerformanceState') == -1:
+            item['cpqSeCpuCurrentPerformanceState'] = None
+        if item.get('cpqSeCpuMinPerformanceState') == -1:
+            item['cpqSeCpuMinPerformanceState'] = None
+        if item.get('cpqSeCpuMaxPerformanceState') == -1:
+            item['cpqSeCpuMaxPerformanceState'] = None
     return state

--- a/lib/check/system.py
+++ b/lib/check/system.py
@@ -70,10 +70,4 @@ async def check_system(
         item.pop('cpqSeCPUSerialNumberMfgr', None)
         item.pop('cpqSeCpuArchitectureRevision', None)
         item.pop('cpqSeCpuHwLocation', None)
-        if item.get('cpqSeCpuCurrentPerformanceState') == -1:
-            item['cpqSeCpuCurrentPerformanceState'] = None
-        if item.get('cpqSeCpuMinPerformanceState') == -1:
-            item['cpqSeCpuMinPerformanceState'] = None
-        if item.get('cpqSeCpuMaxPerformanceState') == -1:
-            item['cpqSeCpuMaxPerformanceState'] = None
     return state


### PR DESCRIPTION
## Description

Some metrics might return values which represent "not supported" or "not exists".
Set those metrics to `null`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Test using alpha version

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
